### PR TITLE
Add openClassDefault setting to allow for modification of "CoverPop-open" class name

### DIFF
--- a/CoverPop.js
+++ b/CoverPop.js
@@ -25,6 +25,9 @@
             // close if someone clicks an element with this class and continue default action
             closeClassDefault: 'CoverPop-close-go',
 
+            // set class name added to HTML element when CoverPop is opened
+            openClassDefault: 'CoverPop-open',
+
             // change the cookie name
             cookieName: '_CoverPop',
 
@@ -196,7 +199,7 @@
             return;
         }
 
-        util.addClass($el.html, 'CoverPop-open');
+        util.addClass($el.html, settings.openClassDefault);
 
         // bind close events and prevent default event
         if ($el.closeClassNoDefaultEls.length > 0) {
@@ -227,7 +230,7 @@
     };
 
     CoverPop.close = function(e) {
-        util.removeClass($el.html, 'CoverPop-open');
+        util.removeClass($el.html, settings.openClassDefault);
         util.setCookie(settings.cookieName, settings.expires);
 
         // unbind escape detection to document

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ CoverPop.start({
     expires:             30,                     // duration (in days) before it pops up again
     closeClassNoDefault: 'CoverPop-close',       // close if someone clicks an element with this class and prevent default action
     closeClassDefault:   'CoverPop-close-go',    // close if someone clicks an element with this class and continue default action
+    openClassDefault:    'CoverPop-open',        // set class name added to HTML element when CoverPop is opened
     cookieName:          '_CoverPop',            // to change the plugin cookie name
     onPopUpOpen:         function() {},          // on popup open callback function
     onPopUpClose:        function() {},          // on popup close callback function


### PR DESCRIPTION
Here's an implementation of an openClassDefault setting (rather than hardcoding "CoverPop-open") along with updated documentation in README.md for this setting (to resolve #12).