### PR TITLE
Update the Demo URL in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CoverPop is modal splash page plugin that is easily styleable.
 
 ## Demo
 
-[View Demo](http://tylerpearson.github.io/CoverPop/)
+[View Demo](http://coverpopjs.com/demo/default)
 
 ## Usage
 


### PR DESCRIPTION
The current Demo URL redirects to http://tylerp.me/coverpop/ (which 404s) so I simply switched it out for the Demo page on the current CoverPop website (http://coverpopjs.com/demo/default).
